### PR TITLE
Add more extensive UTF support to URL validations.

### DIFF
--- a/lib/validator.ex
+++ b/lib/validator.ex
@@ -3,7 +3,50 @@ defmodule Validator do
 
   @uuid ~r/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
   #regex adapted under MIT license from https://gist.github.com/dperini/729294
-  @url ~r/\A(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!127(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\X-\X0-9]+-?)*[a-z\X-\X0-9]+)(?:\.(?:[a-z\X-\X0-9]+-?)*[a-z\X-\X0-9]+)*(?:\.(?:[a-z\X-\X]{2,})))(?::\d{2,5})?(?:\/[^\s]*)?\z/i
+  @url ~r/
+    \A
+
+    # protocol identifier
+    (?:(?:https?|ftp):\/\/)
+
+    # user:passs authentication
+    (?:\S+(?::\S*)?@)?
+
+    (?:
+      # IP address exclusion
+      # private & local networks
+      (?!10(?:\.\d{1,3}){3})
+      (?!127(?:\.\d{1,3}){3})
+      (?!169\.254(?:\.\d{1,3}){2})
+      (?!192\.168(?:\.\d{1,3}){2})
+      (?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})
+
+      # IP address dotted notation octets
+      # excludes loopback network 0.0.0.0
+      # excludes reserved space >= 224.0.0.0
+      # exculeds network & broadcast addresses
+      (?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])
+      (?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}
+      (?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))
+    |
+      # host name
+      (?:(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)
+
+      # domain name
+      (?:\.(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)*
+
+      # TLD identifier
+      (?:\.(?:[a-z\x{00a1}-\x{ffff}]{2,}))
+    )
+
+    # port number
+    (?::\d{2,5})?
+
+    # resource path
+    (?:\/[^\s]*)?
+
+    \z
+  /iux
   #email regex adapted from: https://tools.ietf.org/html/rfc5322#section-3.4  with help from: http://www.elixre.uk/ 
   @email ~r/\A(?=[a-z0-9@.!#$%&'*+\/=?^_`{|}~-]{6,254}\z)(?=[a-z0-9.!#$%&'*+\/=?^_`{|}~-]{1,64}@)[a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*@(?:(?=[a-z0-9-]{1,63}\.)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?=[a-z0-9-]{1,63}\z)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\z/
 

--- a/test/validator_test.exs
+++ b/test/validator_test.exs
@@ -97,14 +97,17 @@ defmodule ValidatorTest do
       "http://foo.bar/?q=Test%20URL-encoded%20stuff",
       "http://1337.net",
       "http://a.b-c.de",
-      "http://223.255.255.254"
+      "http://223.255.255.254",
+      "http://➡.ws/䨹",
+      "http://مثال.إختبار",
+      "http://例子.测试"
     ]
     Enum.each(urls, fn (url) ->
       params = %{"url" => url}
       struct = %Thing{}
 
       changeset = cast(struct, params, ~w(url))
-      assert Validator.validate_url(changeset, :url).valid?
+      assert Validator.validate_url(changeset, :url).valid?, "#{url} is not valid"
     end)
   end
 


### PR DESCRIPTION
Also add tests to prove this works.

Also, split the monster regex line into multiple lines with comments,
making it easier to understand, debug, and maintain.

Compiles on Elixir 1.4.4/OTP 20RC2

Fixes #9